### PR TITLE
Allow users to customize flags images size

### DIFF
--- a/packages/multilingual/controller.php
+++ b/packages/multilingual/controller.php
@@ -16,6 +16,18 @@ class MultilingualPackage extends Package {
 	
 	public function on_start() {
 		define('DIRNAME_IMAGES_LANGUAGES', 'flags');
+		if(!defined('MULTILINGUAL_FLAGS_WIDTH')) {
+			/** Width of multilingual flags.
+			* @var int
+			*/
+			define('MULTILINGUAL_FLAGS_WIDTH', 16);
+		}
+		if(!defined('MULTILINGUAL_FLAGS_HEIGHT')) {
+			/** Height of multilingual flags.
+			* @var int
+			*/
+			define('MULTILINGUAL_FLAGS_HEIGHT', 16);
+		}
 		
 		// checks to see if the user should be redirected to the default language home page instead of the / home page.
 		Events::extend('on_start', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');

--- a/packages/multilingual/helpers/interface/flag.php
+++ b/packages/multilingual/helpers/interface/flag.php
@@ -25,7 +25,7 @@ class InterfaceFlagHelper {
 				if ($filePathOnly) {
 					return $icon;
 				} else {
-					return '<img class="ccm-region-flag" id="ccm-region-flag-' . $region . '" width="16" height="16" src="' . $icon . '" alt="' . $region . '" />';
+					return '<img class="ccm-region-flag" id="ccm-region-flag-' . $region . '" width="' . MULTILINGUAL_FLAGS_WIDTH . '" height="' . MULTILINGUAL_FLAGS_HEIGHT . '" src="' . $icon . '" alt="' . $region . '" />';
 				}
 			}
 		}


### PR DESCRIPTION
The package allows to customize the flags images, but their size is fixed to 16x16.
With this change the users can define in their /config/site.php two constants (MULTILINGUAL_FLAGS_WIDTH and MULTILINGUAL_FLAGS_HEIGHT) that allow to customize the users flag size.
