### PR TITLE
Add seo flags

### DIFF
--- a/packages/multilingual/blocks/switch_language/templates/seo_flags/view.css
+++ b/packages/multilingual/blocks/switch_language/templates/seo_flags/view.css
@@ -1,0 +1,3 @@
+div.ccm-multilingual-switch-language-flags {display: inline;}
+div.ccm-multilingual-switch-language-flags-label {float: left; margin-right: 8px}
+div.ccm-multilingual-switch-language-flags a {padding: 2px; float: left;}

--- a/packages/multilingual/blocks/switch_language/templates/seo_flags/view.php
+++ b/packages/multilingual/blocks/switch_language/templates/seo_flags/view.php
@@ -1,0 +1,15 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+$ih = Loader::helper("interface/flag", 'multilingual');
+$interfacePageHelper = Loader::helper('interface/page', 'multilingual');
+$navigationHelper = Loader::helper('navigation');
+$page = Page::getCurrentPage();
+?><div class="ccm-multilingual-switch-language-flags"><?php
+	if(strlen($label)) {
+		?><div class="ccm-multilingual-switch-language-flags-label"><?php echo $label; ?></div><?php
+	}
+	foreach($languageSections as $ml) {
+		?><a href="<?php echo $navigationHelper->getLinkToCollection($interfacePageHelper->getTranslatedPageWithAliasSupport($page, $ml, true)); ?>" class="<?php if($activeLanguage == $ml->getCollectionID()) { ?>ccm-multilingual-active-flag<?php } ?>"><?php
+			echo $ih->getSectionFlagIcon($ml);
+		?></a><?php
+	}
+?></div>


### PR DESCRIPTION
This pull request adds a new block template to switch_language called
seo_flags, similar to the flags template, except that:
- the destination link of the flags is the final url of the translated
  pages
- the ccm-multilingual-switch-language-flags-label is printed out only
  if $label is not empty.
