### PR TITLE
change "undefined variable" to a defined one in package controller

### DIFF
--- a/packages/multilingual/controller.php
+++ b/packages/multilingual/controller.php
@@ -134,7 +134,7 @@ class MultilingualPackage extends Package {
 		$rows = $db->getAll("SELECT * FROM MultilingualSections");
 		if(is_array($rows) && count($rows)) {
 			foreach($rows as $r) {
-				if(strlen($r['msLanguage']) && !strlen($row['msLocale'])) {
+				if(strlen($r['msLanguage']) && !strlen($r['msLocale'])) {
 					$locale = $r['msLanguage'].(strlen($r['msIcon'])?"_".$r['msIcon']:"");					
 					$db->query("UPDATE MultilingualSections SET msLocale = ? WHERE cID = ?",array($locale, $r['cID']));
 				}


### PR DESCRIPTION
My IDE complained about "undefined variable $rows" so I changed it to $r.

See also bug report: http://www.concrete5.org/index.php?cID=504422
