### PR TITLE
Fixed session default locale, it now checks user's default language.

### DIFF
--- a/packages/multilingual/helpers/default_language.php
+++ b/packages/multilingual/helpers/default_language.php
@@ -49,8 +49,8 @@ class DefaultLanguageHelper {
 			return $_COOKIE['DEFAULT_LOCALE'];
 		}
 
-		$u = new User();
-		if ($u->isLoggedIn()) {
+		if (User::isLoggedIn()) {
+			$u = new User();
 			$userDefaultLanguage = $u->getUserDefaultLanguage();
 			if ($userDefaultLanguage != '') {
 				if (is_object(MultilingualSection::getByLocale($userDefaultLanguage)) || ($userDefaultLanguage == 'en_US' && Page::getCurrentPage()->cID != 1)) {


### PR DESCRIPTION
User's default language was not used with internationalization addon.
This caused site to use predefined default for the site, even if user had selected different default.

Now default language will be returned by user's choise if site has corresponding locale available.

If current page is anything but homepage, `en_US` is allowed even if it is not available in content sections. That is because site might not have it, but you might like to use dashboard in english on a non english site.

In homepage only existing content section locales are allowed even for user's default, because existing locale is needed in case of forwarding rules.
