### PR TITLE
Remove locales from languages

### DIFF
--- a/packages/multilingual/libraries/content_localization.php
+++ b/packages/multilingual/libraries/content_localization.php
@@ -3,7 +3,12 @@
 class MultilingualContentLocalization {
 
 	public function getLanguages() {
-		$r = Zend_Locale::getTranslationList('language',ACTIVE_LOCALE);
-		return $r;
-	}		
+		$languages = array();
+		foreach(Zend_Locale::getTranslationList('language', ACTIVE_LOCALE) as $key => $name) {
+			if(strpos($key, '_') === false) {
+				$languages[$key] = $name;
+			}
+		}
+		return $languages;
+	}
 }


### PR DESCRIPTION
The result of `Zend_Locale::getTranslationList('language')` may contain locales (for example: `en_US`) in addition to languages (for example: `en`).
Let's remove them.
