### PR TITLE
Set ACTIVE_LOCALE depending on the current page

### DIFF
--- a/packages/multilingual/controller.php
+++ b/packages/multilingual/controller.php
@@ -13,7 +13,16 @@ class MultilingualPackage extends Package {
 	public function getPackageName() {
 		return t('Internationalization');
 	}
-	
+
+	public function warmUp() {
+		if(!defined('ACTIVE_LOCALE')) {
+			$locale = Loader::helper('section', 'multilingual')->getLocale(false);
+			if(is_string($locale) && strlen($locale)) {
+				define('ACTIVE_LOCALE', $locale);
+			}
+		}
+	}
+
 	public function on_start() {
 		define('DIRNAME_IMAGES_LANGUAGES', 'flags');
 		if(!defined('MULTILINGUAL_FLAGS_WIDTH')) {

--- a/packages/multilingual/helpers/section.php
+++ b/packages/multilingual/helpers/section.php
@@ -65,14 +65,16 @@ class SectionHelper {
 	 * based first on path within the site (section) or session if not available
 	 * @return string
 	*/
-	public function getLocale() {
+	public function getLocale($setDefaultLocale = true) {
 		$ms = MultilingualSection::getCurrentSection();
 		if (is_object($ms)) {
 			$lang = $ms->getLocale();
 		} else {
 			$lang = Loader::helper('default_language','multilingual')->getSessionDefaultLocale();
 		}
-		$_SESSION['DEFAULT_LOCALE'] = (string) $lang;
+		if($setDefaultLocale) {
+			$_SESSION['DEFAULT_LOCALE'] = (string) $lang;
+		}
 		return (string) $lang;
 	}
 }


### PR DESCRIPTION
### THIS IS JUST A THINK-ABOUT PULL REQUEST

Let's implement the controller->warmUp method that sets the ACTIVE_LOCALE to the current page locale before the locale-dependent defines are defined.

Related core pull request: https://github.com/concrete5/concrete5/pull/1375