### PR TITLE
rel="alternate" hreflang tag should not exclude language of page itself.

### DIFF
--- a/packages/multilingual/helpers/interface/page.php
+++ b/packages/multilingual/helpers/interface/page.php
@@ -152,7 +152,10 @@ class InterfacePageHelper {
 						$isRoot = false;
 					}
 					foreach(self::$_allLanguages as $otherLang) {
-						if($isRoot) {
+						if($otherLang->msLocale == $lang->msLocale) {
+							$otherPage = $page;
+						}
+						elseif($isRoot) {
 							$otherPage = $otherLang;
 						}
 						else {


### PR DESCRIPTION
I watched a video below. Google says "hreflang should specify all alternates on eace page, including the page itself", but multilingual add-on does not.

Expanding your site to more languages (about 9:49)
http://www.youtube.com/watch?v=8ce9jv91beQ

https://support.google.com/webmasters/answer/189077

Multilingual sitemap already has alternates of all languages.
