### PR TITLE
Move the default language process to on_before_process event

### DIFF
--- a/packages/multilingual/controller.php
+++ b/packages/multilingual/controller.php
@@ -30,10 +30,10 @@ class MultilingualPackage extends Package {
 		}
 		
 		// checks to see if the user should be redirected to the default language home page instead of the / home page.
-		Events::extend('on_start', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
+		Events::extend('on_before_process', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
 		
 		// adds the site translation files to the translation library so strings wrapped in t('') will be translated
-		Events::extend('on_start', 'DefaultLanguageHelper', 'setupSiteInterfaceLocalization', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
+		Events::extend('on_before_process', 'DefaultLanguageHelper', 'setupSiteInterfaceLocalization', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
 
 		// Ensure's the language tags are set in the header
 		//Events::extend('on_start', 'TranslatedPagesHelper', 'addMetaTags', 'packages/' . $this->pkgHandle . '/helpers/translated_pages.php');


### PR DESCRIPTION
Now, setupSiteInterfaceLocalization method got to be able to change core locale, but this is not enough. Some block messages like error messages on Form block are not still localized. Let's move setup localization process to on_before_process event.

NOTE: This PR is work in progress. We have to check app version for backward compatibility.
