### PR TITLE
Use the core sitemap.xml generation

### DIFF
--- a/packages/multilingual/CHANGELOG
+++ b/packages/multilingual/CHANGELOG
@@ -1,6 +1,7 @@
 1.3.2dev
 	- added filter by name to multilingual page report
 	- added page path below page name on multilingual page report for context
+	- use general GenerateSitemapJob if available (from concrete5 5.6.3)
 
 1.3.1
 	- Page Report tool now trips workflow (if it exists) on page creation in multilingual trees.

--- a/packages/multilingual/helpers/sitemap_job.php
+++ b/packages/multilingual/helpers/sitemap_job.php
@@ -1,0 +1,47 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
+class SitemapJobHelper {
+
+	/** Can we use the standard sitemap.xml generation job?
+	* @return bool
+	*/
+	public function canUseStandardSitemapJob() {
+		if(version_compare(APP_VERSION, '5.6.3') >= 0) {
+			$job = Job::getByHandle('generate_sitemap');
+			if(is_object($job)) {
+				switch($job->getJobStatus()) {
+					case 'ENABLED':
+					case 'RUNNING':
+					case 'ERROR':
+						return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/** Extends a sitemap node by adding multilingual-related info
+	* @param $xmlNode SimpleXMLElement
+	* @param $page Page
+	*/
+	public function extendSitemapNode($xmlNode, $page) {
+		static $tp;
+		if(!isset($tp)) {
+			$tp = Loader::helper('translated_pages', 'multilingual');
+		}
+		$translatedPages = $tp->getTranslatedPages($page);
+		if(count($translatedPages)) {
+			$rootNode = current($xmlNode->xpath('/*'));
+			if(empty($rootNode['xmlns:xhtml'])) {
+				$rootNode['xmlns:xhtml'] = 'http://www.w3.org/1999/xhtml';
+			}
+		}
+		foreach($translatedPages as $locale => $translatedPage) {
+			$altMeta = $tp->getAltMeta($locale, $translatedPage, 'xmlns:xhtml:link');
+			$xmlSubNode = $xmlNode->addChild(array_shift($altMeta));
+			foreach($altMeta as $attribute => $value) {
+				$xmlSubNode->addAttribute($attribute, $value);
+			}
+		}
+	}
+}

--- a/packages/multilingual/helpers/translated_pages.php
+++ b/packages/multilingual/helpers/translated_pages.php
@@ -46,18 +46,21 @@ class TranslatedPagesHelper {
 		}
 		return $tpages;
 	}
-
-	public function altMeta($lang,$page,$tag='link') {
+	
+	public function getAltMeta($lang, $page, $tag = 'link') {
 		list($iso63911,$country) = explode('_',strtolower($lang));
 		$nh = Loader::helper('navigation');
 		$uri = $nh->getCollectionURL($page);
-		$meta = array(
+		return array(
 			$tag,
 			'rel'=>'alternate',
 			'hreflang'=>$iso63911."-".$country,
 			'href'=>$uri
 		);
-		return self::renderTag($meta);
+	}
+
+	public function altMeta($lang, $page, $tag = 'link') {
+		return self::renderTag(self::getAltMeta($lang, $page, $tag));
 	}
 
 	protected function renderTag($arr) {

--- a/packages/multilingual/jobs/generate_multilingual_sitemap.php
+++ b/packages/multilingual/jobs/generate_multilingual_sitemap.php
@@ -18,6 +18,9 @@ class GenerateMultilingualSitemap extends Job {
 		if(!defined('ENABLE_MULTILINGUAL_SITEMAPXML') || !ENABLE_MULTILINGUAL_SITEMAPXML) {
 			return t("This job is disabled because it may cause excessive load depending on the size of your site.  To enable this job, you must define the constant ENABLE_MULTILINGUAL_SITEMAPXML as true.");
 		}
+		if(Loader::helper('sitemap_job', 'multilingual')->canUseStandardSitemapJob() == true) {
+			return t('This job is useless since the multilingual sitemap generation is integrated in the core sitemap generation job.');
+		}
 
 		$ni = Loader::helper('navigation');
 		$tp = Loader::helper('translated_pages', 'multilingual');


### PR DESCRIPTION
Starting from concrete5 5.6.3 we can integrate the data generated by the standard sitemap.xml generator job, without the need of a duplicated job.

We can use add multilanguage data to the sitemap by extending the `on_sitemap_xml_addingpage` event.

During install or upgrade, the multilingual addon checks if concrete5 is >= 5.6.3, if the sitemap job is installed and enabled.
If so, it does not install the multilingual job and (if ENABLE_MULTILINGUAL_SITEMAPXML is set to true) extend the data from the standard job.
If concrete5 is < 5.6.3, of if the standard job is not available/enabled, nothing changes: we keep the old sitemap job up and running.
