### PR TITLE
Hook startup functions on on_page_view event instead of on_start

### DIFF
--- a/packages/multilingual/controller.php
+++ b/packages/multilingual/controller.php
@@ -30,10 +30,10 @@ class MultilingualPackage extends Package {
 		}
 		
 		// checks to see if the user should be redirected to the default language home page instead of the / home page.
-		Events::extend('on_start', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
+		Events::extend('on_page_view', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
 		
 		// adds the site translation files to the translation library so strings wrapped in t('') will be translated
-		Events::extend('on_start', 'DefaultLanguageHelper', 'setupSiteInterfaceLocalization', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
+		Events::extend('on_page_view', 'DefaultLanguageHelper', 'setupSiteInterfaceLocalization', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
 
 		// Ensure's the language tags are set in the header
 		//Events::extend('on_start', 'TranslatedPagesHelper', 'addMetaTags', 'packages/' . $this->pkgHandle . '/helpers/translated_pages.php');


### PR DESCRIPTION
Setup translation language before startup/process.php.
Related commit: concrete5/concrete5@4fdea7e2a608333620c3d57fc7434aa89e171550

It even works fine on before 5.6.3, but I want to more testing about this change by others.