### PR TITLE
Use standard value for hreflang tag

### DIFF
--- a/packages/multilingual/helpers/interface/page.php
+++ b/packages/multilingual/helpers/interface/page.php
@@ -160,7 +160,7 @@ class InterfacePageHelper {
 								$otherPage = $this->getTranslatedPageWithAliasSupport($page, $otherLang, false);
 							}
 							if($otherPage) {
-								$v->addHeaderItem('<link rel="alternate" hreflang="' . $otherLang->msLocale . '" href="' . $navigation->getLinkToCollection($otherPage) . '" />');
+								$v->addHeaderItem('<link rel="alternate" hreflang="' . str_replace('_', '-', $otherLang->msLocale) . '" href="' . $navigation->getLinkToCollection($otherPage) . '" />');
 							}
 						}
 					}


### PR DESCRIPTION
The hreflang needs to be in form language-country, not language_country.

For instance, we have to use

``` html
<link rel="alternate" hreflang="en-US" href="url" />
```

instead of

``` html
<link rel="alternate" hreflang="en_US" href="url" />
```
