### PR TITLE
make sure we don't redirect non-existent pages

### DIFF
--- a/packages/multilingual/helpers/default_language.php
+++ b/packages/multilingual/helpers/default_language.php
@@ -7,7 +7,7 @@ class DefaultLanguageHelper {
 	public function checkDefaultLanguage() {
 		$req = Request::get();
 		if (!$_SERVER['REQUEST_METHOD'] != 'POST') { 
-			if (!$req->getRequestCollectionPath() && $req->getRequestCollectionID() == 1 && (!$req->isIncludeRequest())) {
+			if (!$req->getRequestPath() && $req->getRequestCollectionID() == 1 && (!$req->isIncludeRequest())) {
 				$p = $req->getCurrentPage();
 				if (is_object($p) && (!$p->isError())) { 
 					$pkg = Package::getByHandle('multilingual');


### PR DESCRIPTION
We've had the problem that scottc's URL director didn't play well with the multilingual add-on if we let it redirect the home page to the language page (e.g. / > /de/).

What I've had to change is simple. Instead of checking the collection path, I'm checking the request path which is set, if we call a URL like http://www.customer.ch/old-page.html. Since concrete5 doesn't know anything about that page, it won't return a collection path, but it returns a request path and then lets the URL director do its magic.

I'm not entirely sure if my change won't have any side effects, but we'll test it on one site where we had that problem. Any feedback appreciated!
