### PR TITLE
use on_page_view to get block action translations

### DIFF
--- a/packages/multilingual/controller.php
+++ b/packages/multilingual/controller.php
@@ -30,10 +30,10 @@ class MultilingualPackage extends Package {
 		}
 		
 		// checks to see if the user should be redirected to the default language home page instead of the / home page.
-		Events::extend('on_start', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
+		Events::extend('on_page_view', 'DefaultLanguageHelper', 'checkDefaultLanguage', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
 		
 		// adds the site translation files to the translation library so strings wrapped in t('') will be translated
-		Events::extend('on_start', 'DefaultLanguageHelper', 'setupSiteInterfaceLocalization', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
+		Events::extend('on_page_view', 'DefaultLanguageHelper', 'setupSiteInterfaceLocalization', 'packages/' . $this->pkgHandle . '/helpers/default_language.php');
 
 		// Ensure's the language tags are set in the header
 		//Events::extend('on_start', 'TranslatedPagesHelper', 'addMetaTags', 'packages/' . $this->pkgHandle . '/helpers/translated_pages.php');

--- a/packages/multilingual/helpers/default_language.php
+++ b/packages/multilingual/helpers/default_language.php
@@ -4,7 +4,7 @@ Loader::model('section', 'multilingual');
 
 class DefaultLanguageHelper {
 
-	public function checkDefaultLanguage() {
+	public function checkDefaultLanguage($page) {
 		$req = Request::get();
 		if (!$_SERVER['REQUEST_METHOD'] != 'POST') { 
 			if (!$req->getRequestCollectionPath() && $req->getRequestCollectionID() == 1 && (!$req->isIncludeRequest())) {
@@ -84,7 +84,7 @@ class DefaultLanguageHelper {
 		return $pkg->config('DEFAULT_LANGUAGE');
 	}
 	
-	public static function setupSiteInterfaceLocalization() {
+	public static function setupSiteInterfaceLocalization($page) {
 		// don't translate dashboard pages
 		$c = Page::getCurrentPage();
 		if($c instanceof Page && Loader::helper('section', 'multilingual')->section('dashboard')) {


### PR DESCRIPTION
on_page_view has been moved to be able to change the locale in concrete5, see comment https://github.com/concrete5/concrete5/pull/1441#issuecomment-35011546

Problem has been explain here:
- http://www.concrete5.org/developers/bugs/5-6-3-1/localization-is-only-partial-under-some-circustances/#625112
- https://www.concrete5.org/marketplace/addons/internationalization/forums/internationalization-package-does-not-change-locale-of-core-bloc/
