### PR TITLE
fix base query in MultilingualPageList without to break the Page Report

### DIFF
--- a/packages/multilingual/models/multilingual_page_list.php
+++ b/packages/multilingual/models/multilingual_page_list.php
@@ -3,13 +3,17 @@ Loader::model("page_list");
 class MultilingualPageList extends PageList {
 
 	public function __construct() {
-		$mslist = MultilingualSection::getList();
-		$query = ',  (select mpRelationID from MultilingualPageRelations where cID = p1.cID LIMIT 1) as mpr';
-		foreach($mslist as $ms) {
-			$query .= ', (select count(mpRelationID) from MultilingualPageRelations where MultilingualPageRelations.mpRelationID = mpr and mpLocale = \'' . $ms->getLocale() . '\') as relationCount'  . $ms->getCollectionID();
-		}
-		$this->setBaseQuery($query);
-	}
+                $this->setBaseQuery();
+        }
+    
+        protected function setBaseQuery($additionalFields = '') {
+                $mslist = MultilingualSection::getList();
+                $query = ',  (select mpRelationID from MultilingualPageRelations where cID = p1.cID LIMIT 1) as mpr';
+                foreach ($mslist as $ms) {
+                        $query .= ', (select count(mpRelationID) from MultilingualPageRelations where MultilingualPageRelations.mpRelationID = mpr and mpLocale = \'' . $ms->getLocale() . '\') as relationCount' . $ms->getCollectionID();
+                }
+                parent::setBaseQuery('' . $query);
+        }
 	
 	public function filterByMissingTargets($targets) {
 		$haveStr .= '';

--- a/packages/multilingual/models/multilingual_page_list.php
+++ b/packages/multilingual/models/multilingual_page_list.php
@@ -12,7 +12,7 @@ class MultilingualPageList extends PageList {
                 foreach ($mslist as $ms) {
                         $query .= ', (select count(mpRelationID) from MultilingualPageRelations where MultilingualPageRelations.mpRelationID = mpr and mpLocale = \'' . $ms->getLocale() . '\') as relationCount' . $ms->getCollectionID();
                 }
-                parent::setBaseQuery('' . $query);
+                parent::setBaseQuery($query . $additionalFields);
         }
 	
 	public function filterByMissingTargets($targets) {


### PR DESCRIPTION
Doing the same as Remo's pull request.(https://github.com/concrete5/addon_internationalization/pull/55/files ) But without to break the Page Report