### PR TITLE
Send a 301 HTTP status

### DIFF
--- a/packages/multilingual/helpers/default_language.php
+++ b/packages/multilingual/helpers/default_language.php
@@ -15,6 +15,7 @@ class DefaultLanguageHelper {
 						$ms = MultilingualSection::getByLocale(DefaultLanguageHelper::getSessionDefaultLocale());
 						if (is_object($ms)) {
 							if ($ms->getCollectionID() != 1) {
+								header('HTTP/1.1 301 Moved Permanently');
 								header('Location: ' . Loader::helper('navigation')->getLinkToCollection($ms, true));
 								exit;
 							}


### PR DESCRIPTION
We have a bilingual website running with concrete5 and I've analyzed the way it's indexed by the Googlebot. The website has two home pages at `/en/` and `/pt/`. The root `/` redirects to one of them depending on the users browser (with `/en/` as fallback).

Now I've noticed the Googlebot indexes the `/en/` page as `/` and doesn't parse the structured data on `/en/`.

To improve SEO I would propose to do a `301 Moved Permanently` redirect instead of a `302 Moved Temporarily`. This makes the Googlebot realize, that the actual content is at `/en/` and the "[link juice](http://moz.com/blog/an-seos-guide-to-http-status-codes)" gets passed to `/en/`.

The only problem I could see is if a user changes his preferred locale and the browser keeps redirecting the root page to the old locale. Maybe we could do a `301` redirect only for the fallback locale?

Thoughts?